### PR TITLE
Add answers to proposals from a CSV file

### DIFF
--- a/lib/tasks/proposals_answer.rake
+++ b/lib/tasks/proposals_answer.rake
@@ -1,0 +1,13 @@
+namespace :proposals_answer do
+  # Add answers with a CSV using this columns (id,state,answer) the valid states are (accepted,rejected and evaluating)
+  desc "Add answers to proposals from a CSV file"
+  task add: :environment do
+    CSV.foreach(ARGV[1], headers: true) do |row|
+      proposal = Decidim::Proposals::Proposal.find(row['id']) rescue nil
+      unless proposal.nil?
+        proposal.update state: row['state'], answer: {"es": "#{row['answer']}"}, answered_at: DateTime.now
+        puts "Answered Proposal ##{proposal.id}: #{proposal.title}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add answers with a CSV using this columns (id,state,answer) the valid states are (accepted,rejected and evaluating)

the usage is:
`rake proposals_answer:add /path/to/file.csv`